### PR TITLE
fix: add `register_filters` back again

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ Use the `Qk-Variant` header to specify which template variant to render:
 
 The `|variant("table")` filter renders each task using `Task.table.html`.
 
+**IMPORTANT**
+
+If creating your own template environment (such as with FastAPI templating feature),
+use `register_filters` to register our filters (like `variant`) into your templates.
+
+```py
+from fastapi.templating import Jinja2Templates
+templates = Jinja2Templates(directory="myapp/templates")
+qk.register_filters(templates.env)
+```
+
 #### DELETE Requests with HTMX
 
 QuikUI automatically handles DELETE operations for both REST and HTMX clients:

--- a/quikui/__init__.py
+++ b/quikui/__init__.py
@@ -1,4 +1,4 @@
-from .components import BaseComponent, is_component
+from .components import BaseComponent
 from .decorators import render_component
 from .dependencies import QkVariant, RequestIfHtmlResponseNeeded
 from .error_handlers import setup_error_handlers
@@ -10,6 +10,8 @@ from .exceptions import (
 )
 from .jinja import (
     get_template_context,
+    is_component,
+    register_filters,
     render_component_variant,
     set_context_provider,
 )
@@ -27,5 +29,6 @@ __all__ = [
     "NoTemplateFoundError",
     "ResponseNotRenderableError",
     "TemplatedHTTPException",
+    "register_filters",
     "setup_error_handlers",
 ]

--- a/quikui/components.py
+++ b/quikui/components.py
@@ -6,14 +6,8 @@ from jinja2 import Environment, PackageLoader, Template
 from jinja2 import TemplateNotFound as Jinja2TemplateNotFound
 from pydantic import BaseModel
 
-from quikui.jinja import render_component_variant
-
 from .exceptions import NoTemplateFoundError
-
-
-def is_component(value: Any) -> bool:
-    """Helper function to check if a value is a BaseComponent instance."""
-    return isinstance(value, BaseComponent)
+from .jinja import register_filters
 
 
 class BaseComponent(BaseModel):
@@ -122,12 +116,7 @@ class BaseComponent(BaseModel):
             autoescape=True,
         )
         # NOTE: Add our special filters here
-        env.filters.update(
-            {
-                "is_component": is_component,
-                "variant": render_component_variant,
-            }
-        )
+        register_filters(env)
         return env
 
     @classmethod


### PR DESCRIPTION
This is needed in the case that you are defining your own environment e.g.:

```py
from fastapi.templating import Jinja2Templates
templates = Jinja2Templates(directory="myapp/templates")
qk.register_filters(templates.env)
```